### PR TITLE
feat: read mobile device applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,24 +4,24 @@
 [![Node.js Version](https://img.shields.io/badge/node-%3E%3D18.0.0-brightgreen)](https://nodejs.org)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.8-blue)](https://www.typescriptlang.org/)
 [![MCP SDK](https://img.shields.io/badge/MCP%20SDK-1.0.0-purple)](https://github.com/modelcontextprotocol/sdk)
-[![Tools](https://img.shields.io/badge/Tools-108-orange)]()
+[![Tools](https://img.shields.io/badge/Tools-110-orange)]()
 [![Resources](https://img.shields.io/badge/Resources-12-green)]()
 [![Prompts](https://img.shields.io/badge/Prompts-12-blue)]()
 
 A comprehensive MCP (Model Context Protocol) server that enables AI assistants to interact with Jamf Pro for complete Apple device management. Works with Claude Desktop and **ChatGPT** (via MCP Connectors).
 
-**Two modes**: Classic Mode (108 individual tools) or **Code Mode** (2 tools + sandboxed JavaScript SDK)
+**Two modes**: Classic Mode (110 individual tools) or **Code Mode** (2 tools + sandboxed JavaScript SDK)
 
 ### What's New in v2.2
 
-- **Code Mode** — a new execution model that exposes just 2 MCP tools (`jamf_search` + `jamf_execute`) instead of 108 individual tools. The agent writes JavaScript that runs in a sandboxed `node:vm` context with a typed Jamf API client, enabling complex multi-step workflows in a single tool call. Includes capability-based access control, budget tracking, plan/apply workflow, and an approval gate for high-impact commands.
+- **Code Mode** — a new execution model that exposes just 2 MCP tools (`jamf_search` + `jamf_execute`) instead of 110 individual tools. The agent writes JavaScript that runs in a sandboxed `node:vm` context with a typed Jamf API client, enabling complex multi-step workflows in a single tool call. Includes capability-based access control, budget tracking, plan/apply workflow, and an approval gate for high-impact commands.
 - **Concurrency limiting** — semaphore-style `ConcurrencyLimiter` (default 5, configurable via `JAMF_MAX_CONCURRENCY`) prevents 429 rate-limit errors. Applied to both the core API client and Code Mode sandbox.
 - **Policy caching** — `getPolicyDetails` results are now cached to avoid redundant API calls, with automatic invalidation on policy writes.
 - **Static computer group XML fix** — `createStaticComputerGroup` and `updateStaticComputerGroup` now use proper XML via `XmlBuilder` (with escaping) instead of broken JSON or raw template literals.
 
 ### What's in v2.1
 
-- **108 tools** (up from 56) — expanded coverage across the full Jamf Pro API and Classic API
+- **110 tools** (up from 56) — expanded coverage across the full Jamf Pro API and Classic API
 - **12 resources** — all returning live data including compliance, storage, OS versions, encryption, and patch reports
 - **12 workflow prompts** — guided templates for common admin tasks like onboarding, offboarding, security audits, and staged rollouts
 - **Compound tools** — single-call operations like `getFleetOverview`, `getDeviceFullProfile`, `getSecurityPosture`, and `getPolicyAnalysis` that combine multiple API calls behind the scenes
@@ -54,7 +54,7 @@ See our [ChatGPT Quick Start Guide](chatgpt/QUICK_START.md) for 5-minute setup.
 
 ## Code Mode (New)
 
-Code Mode replaces 108 individual MCP tools with just 2:
+Code Mode replaces 110 individual MCP tools with just 2:
 
 | Tool | Purpose |
 |---|---|
@@ -63,7 +63,7 @@ Code Mode replaces 108 individual MCP tools with just 2:
 
 **Why Code Mode?** This implementation is inspired by [Cloudflare's Code Mode pattern](https://blog.cloudflare.com/code-mode-mcp/), which addresses a fundamental tension in MCP: agents need many tools to do useful work, but every tool definition consumes context window tokens. Cloudflare found that exposing their full API as individual MCP tools would consume over 1 million tokens — more than the entire context window of most models. Their solution: collapse everything into a `search` + `execute` pattern where agents discover APIs on demand and write code against a typed SDK, reducing token usage by up to 99.9%.
 
-We applied the same pattern to Jamf Pro. Our 108 Classic Mode tools consume ~40,000 tokens of tool definitions. Code Mode reduces that to ~1,000 tokens (2 tool definitions) while retaining access to the full API surface. The agent uses `jamf_search` to discover methods, then writes JavaScript that runs in a sandboxed `node:vm` context. This also enables multi-step workflows in a single tool call — chaining API calls, filtering results, and building reports without LLM round-trips between each step.
+We applied the same pattern to Jamf Pro. Our 110 Classic Mode tools consume ~40,000 tokens of tool definitions. Code Mode reduces that to ~1,000 tokens (2 tool definitions) while retaining access to the full API surface. The agent uses `jamf_search` to discover methods, then writes JavaScript that runs in a sandboxed `node:vm` context. This also enables multi-step workflows in a single tool call — chaining API calls, filtering results, and building reports without LLM round-trips between each step.
 
 **Safety features:**
 - **Plan/Apply workflow** — run with `mode: "plan"` to preview all writes without executing, then `mode: "apply"` to commit
@@ -129,7 +129,7 @@ Run the benchmark yourself:
 npm run benchmark   # requires JAMF_URL, JAMF_CLIENT_ID, JAMF_CLIENT_SECRET
 ```
 
-## Classic Mode (108 Tools)
+## Classic Mode (110 Tools)
 
 ## What You Can Do
 
@@ -143,7 +143,7 @@ Ask natural language questions about your Jamf fleet:
 - "Retrieve the LAPS password for this device"
 - "Show me patch compliance across the fleet"
 
-## Tools (108)
+## Tools (110)
 
 ### Compound Tools (Start Here)
 These combine multiple API calls into a single operation:
@@ -223,6 +223,8 @@ These combine multiple API calls into a single operation:
 - **searchMobileDevices**: Search mobile devices by name, serial, or UDID
 - **getMobileDeviceDetails**: Detailed mobile device information
 - **listMobileDevices**: List all mobile devices
+- **listMobileDeviceApplications**: List mobile device applications configured for delivery
+- **getMobileDeviceApplicationDetails**: Get a delivered mobile application definition and scope details
 - **updateMobileDeviceInventory**: Force inventory update on a mobile device
 - **sendMDMCommand**: Send MDM commands — lock, wipe, clear passcode, lost mode, settings (requires confirmation)
 - **listMobileDeviceGroups**: List mobile device groups
@@ -428,7 +430,7 @@ For read-only mode:
 ## Architecture
 
 ```
-                    ┌─ Classic Mode (108 tools) ──┐
+                    ┌─ Classic Mode (110 tools) ──┐
 Claude Desktop ──>  │  MCP Server (stdio)          │──>  Jamf Pro API
                     ├─ Code Mode (2 tools) ────────┤
                     │  jamf_search + jamf_execute   │──>  (sandboxed VM)  ──>  Jamf Pro API

--- a/src/__tests__/code-mode/policy-engine.test.ts
+++ b/src/__tests__/code-mode/policy-engine.test.ts
@@ -15,6 +15,15 @@ describe('PolicyEngine', () => {
       expect(policy).toEqual({ classification: 'read', capability: 'read:computers' });
     });
 
+    it('requires a dedicated capability for mobile device applications', () => {
+      const policy = getMethodPolicy('listMobileDeviceApplications');
+      expect(policy).toEqual({
+        classification: 'read',
+        capability: 'read:mobile_device_applications',
+      });
+      expect(getMethodPolicy('getMobileDeviceApplicationDetails')).toEqual(policy);
+    });
+
     it('returns undefined for unknown methods', () => {
       expect(getMethodPolicy('nonExistentMethod')).toBeUndefined();
     });
@@ -24,6 +33,12 @@ describe('PolicyEngine', () => {
     it('allows access when capability is granted', () => {
       const result = checkAccess('getAllComputers', ['read:computers']);
       expect(result.allowed).toBe(true);
+    });
+
+    it('does not grant application delivery reads with mobile device inventory access', () => {
+      const result = checkAccess('listMobileDeviceApplications', ['read:mobile_devices']);
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain('read:mobile_device_applications');
     });
 
     it('denies access when capability is not granted', () => {

--- a/src/__tests__/code-mode/sandbox-runner.test.ts
+++ b/src/__tests__/code-mode/sandbox-runner.test.ts
@@ -57,6 +57,8 @@ function createMockClient(overrides: Partial<IJamfApiClient> = {}): IJamfApiClie
     sendMDMCommand: jest.fn().mockResolvedValue(undefined),
     getMobileDeviceGroups: jest.fn().mockResolvedValue([]),
     getMobileDeviceGroupDetails: jest.fn().mockResolvedValue({}),
+    listMobileDeviceApplications: jest.fn().mockResolvedValue([{ id: '123', name: 'Example Mobile App' }]),
+    getMobileDeviceApplicationDetails: jest.fn().mockResolvedValue({ general: { id: '123', name: 'Example Mobile App' } }),
     getInventorySummary: jest.fn().mockResolvedValue({}),
     getPolicyComplianceReport: jest.fn().mockResolvedValue({}),
     getPackageDeploymentStats: jest.fn().mockResolvedValue({}),
@@ -153,6 +155,34 @@ describe('SandboxRunner', () => {
       expect(result.logs.some(l => l.msg.some(m =>
         typeof m === 'string' && m.includes('Access denied'),
       ))).toBe(true);
+    });
+
+    it('executes mobile device application reads with their dedicated capability', async () => {
+      const client = createMockClient();
+      const result = await execute(client, {
+        code: 'return await jamf.listMobileDeviceApplications();',
+        mode: 'plan',
+        capabilities: ['read:mobile_device_applications'],
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.returnValue).toEqual([{ id: '123', name: 'Example Mobile App' }]);
+      expect(result.metrics.reads).toBe(1);
+      expect(client.listMobileDeviceApplications).toHaveBeenCalledWith();
+    });
+
+    it('executes mobile device application detail reads with their dedicated capability', async () => {
+      const client = createMockClient();
+      const result = await execute(client, {
+        code: 'return await jamf.getMobileDeviceApplicationDetails("123");',
+        mode: 'plan',
+        capabilities: ['read:mobile_device_applications'],
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.returnValue).toEqual({ general: { id: '123', name: 'Example Mobile App' } });
+      expect(result.metrics.reads).toBe(1);
+      expect(client.getMobileDeviceApplicationDetails).toHaveBeenCalledWith('123');
     });
   });
 

--- a/src/__tests__/code-mode/search-index.test.ts
+++ b/src/__tests__/code-mode/search-index.test.ts
@@ -5,7 +5,7 @@ describe('SearchIndex', () => {
   describe('getAllEntries', () => {
     it('returns all catalog entries', () => {
       const entries = getAllEntries();
-      // 111 API methods + 3 helpers
+      // API methods plus helper functions
       expect(entries.length).toBeGreaterThan(100);
     });
 
@@ -55,6 +55,16 @@ describe('SearchIndex', () => {
     it('finds methods by description keywords', () => {
       const results = search('serial number');
       expect(results.length).toBeGreaterThan(0);
+    });
+
+    it('finds mobile device application delivery inventory', () => {
+      const results = search('mobile device applications');
+      expect(results.map(result => result.name)).toContain('listMobileDeviceApplications');
+      expect(results.map(result => result.name)).toContain('getMobileDeviceApplicationDetails');
+      expect(results.find(result => result.name === 'listMobileDeviceApplications')).toMatchObject({
+        capabilities: ['read:mobile_device_applications'],
+        readOnly: true,
+      });
     });
 
     it('ranks exact name matches highest', () => {

--- a/src/code-mode/policy-engine.ts
+++ b/src/code-mode/policy-engine.ts
@@ -83,6 +83,10 @@ const METHOD_POLICIES: Record<string, MethodPolicy> = {
   getMobileDeviceGroups:        { classification: 'read', capability: 'read:mobile_devices' },
   getMobileDeviceGroupDetails:  { classification: 'read', capability: 'read:mobile_devices' },
 
+  // Mobile Device Applications
+  listMobileDeviceApplications: { classification: 'read', capability: 'read:mobile_device_applications' },
+  getMobileDeviceApplicationDetails: { classification: 'read', capability: 'read:mobile_device_applications' },
+
   // Reports & Analytics
   getInventorySummary:          { classification: 'read', capability: 'read:reports' },
   getPolicyComplianceReport:    { classification: 'read', capability: 'read:reports' },

--- a/src/code-mode/search-index.ts
+++ b/src/code-mode/search-index.ts
@@ -76,6 +76,10 @@ const CATALOG: SearchIndexEntry[] = [
   { name: 'getMobileDeviceGroups',       signature: '(type?: GroupType) => Promise<any[]>',     description: 'List mobile device groups',               category: 'mobile_devices', capabilities: ['read:mobile_devices'], readOnly: true },
   { name: 'getMobileDeviceGroupDetails', signature: '(groupId: string) => Promise<any>',        description: 'Get details for a mobile device group',   category: 'mobile_devices', capabilities: ['read:mobile_devices'], readOnly: true },
 
+  // ── Mobile Device Applications ───────────────────────────────────
+  { name: 'listMobileDeviceApplications', signature: '() => Promise<any[]>', description: 'List all mobile device applications configured for delivery', category: 'mobile_device_applications', capabilities: ['read:mobile_device_applications'], readOnly: true },
+  { name: 'getMobileDeviceApplicationDetails', signature: '(applicationId: string) => Promise<any>', description: 'Get details for a mobile device application configured for delivery', category: 'mobile_device_applications', capabilities: ['read:mobile_device_applications'], readOnly: true },
+
   // ── Reports & Analytics ──────────────────────────────────────────
   { name: 'getInventorySummary',        signature: '() => Promise<any>',                             description: 'Get fleet-wide inventory summary (counts, OS versions, models)',   category: 'reports', capabilities: ['read:reports'], readOnly: true },
   { name: 'getPolicyComplianceReport',  signature: '(policyId: string) => Promise<any>',             description: 'Get compliance report for a specific policy',                      category: 'reports', capabilities: ['read:reports'], readOnly: true },

--- a/src/index-code.ts
+++ b/src/index-code.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * Code Mode entry point — exposes just 2 MCP tools (jamf_search + jamf_execute)
- * instead of the full 108-tool surface. The agent writes JavaScript code
+ * instead of the full 110-tool surface. The agent writes JavaScript code
  * against a typed SDK, executed in a sandboxed VM.
  */
 
@@ -64,7 +64,7 @@ const server = new Server(
 
 ## How Code Mode Works
 
-Instead of 108 individual tools, you have 2 tools:
+Instead of 110 individual tools, you have 2 tools:
 
 1. **jamf_search** — Discover available API methods, their signatures, required capabilities, and categories.
 2. **jamf_execute** — Execute JavaScript code in a sandbox with access to the full Jamf API.
@@ -136,7 +136,7 @@ async function run() {
       rejectUnauthorized: process.env.JAMF_ALLOW_INSECURE !== 'true',
     });
 
-    // Register Code Mode tools (2 tools instead of 108)
+    // Register Code Mode tools (2 tools instead of 110)
     registerCodeModeTools(server, jamfClient);
 
     // Resources and prompts are still available

--- a/src/index-main.ts
+++ b/src/index-main.ts
@@ -14,7 +14,7 @@ const USE_ENHANCED_MODE =
   process.env.JAMF_ENABLE_RATE_LIMITING === 'true' ||
   process.env.JAMF_ENABLE_CIRCUIT_BREAKER === 'true';
 
-// Code mode: 2 tools (jamf_search + jamf_execute) instead of 108
+// Code mode: 2 tools (jamf_search + jamf_execute) instead of 110
 if (USE_CODE_MODE) {
   import('./index-code.js').then(_module => {
     // Module will auto-execute

--- a/src/jamf-client-hybrid.ts
+++ b/src/jamf-client-hybrid.ts
@@ -1999,6 +1999,44 @@ export class JamfApiClientHybrid implements IJamfApiClient {
   }
 
   /**
+   * List all mobile device applications configured for delivery
+   */
+  async listMobileDeviceApplications(): Promise<any[]> {
+    await this.ensureAuthenticated();
+
+    try {
+      logger.info('Listing mobile device applications using Classic API...');
+      const response = await this.axiosInstance.get('/JSSResource/mobiledeviceapplications');
+      return response.data.mobile_device_applications || [];
+    } catch (error) {
+      if (isAxiosError(error)) {
+        throw JamfAPIError.fromAxiosError(error, { operation: 'listMobileDeviceApplications' });
+      }
+      logger.error('Failed to list mobile device applications:', { error: getErrorMessage(error) });
+      throw error;
+    }
+  }
+
+  /**
+   * Get details for a mobile device application configured for delivery
+   */
+  async getMobileDeviceApplicationDetails(applicationId: string): Promise<any> {
+    await this.ensureAuthenticated();
+
+    try {
+      logger.info(`Getting mobile device application details for ${applicationId} using Classic API...`);
+      const response = await this.axiosInstance.get(`/JSSResource/mobiledeviceapplications/id/${applicationId}`);
+      return response.data.mobile_device_application;
+    } catch (error) {
+      if (isAxiosError(error)) {
+        throw JamfAPIError.fromAxiosError(error, { operation: 'getMobileDeviceApplicationDetails', applicationId });
+      }
+      logger.error('Failed to get mobile device application details:', { error: getErrorMessage(error) });
+      throw error;
+    }
+  }
+
+  /**
    * Update mobile device inventory
    */
   async updateMobileDeviceInventory(deviceId: string): Promise<void> {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -186,6 +186,12 @@ const ListMobileDevicesSchema = z.object({
   limit: z.number().optional().default(50).describe('Maximum number of mobile devices to return'),
 });
 
+const ListMobileDeviceApplicationsSchema = z.object({});
+
+const GetMobileDeviceApplicationDetailsSchema = z.object({
+  applicationId: z.string().describe('The mobile device application ID'),
+});
+
 const UpdateMobileDeviceInventorySchema = z.object({
   deviceId: z.string().describe('The mobile device ID to update inventory for'),
 });
@@ -1404,6 +1410,30 @@ export function registerTools(server: Server, jamfClient: IJamfApiClient): void 
               default: 50,
             },
           },
+        },
+        annotations: { readOnlyHint: true, destructiveHint: false },
+      },
+      {
+        name: 'listMobileDeviceApplications',
+        description: 'List all mobile device applications configured for delivery in Jamf Pro',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+        },
+        annotations: { readOnlyHint: true, destructiveHint: false },
+      },
+      {
+        name: 'getMobileDeviceApplicationDetails',
+        description: 'Get detailed information about a mobile device application configured for delivery in Jamf Pro',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            applicationId: {
+              type: 'string',
+              description: 'The mobile device application ID',
+            },
+          },
+          required: ['applicationId'],
         },
         annotations: { readOnlyHint: true, destructiveHint: false },
       },
@@ -3988,6 +4018,33 @@ export function registerTools(server: Server, jamfClient: IJamfApiClient): void 
                 supervised: d.supervised,
               })),
             }, null, 2),
+          };
+
+          return { content: [content] };
+        }
+
+        case 'listMobileDeviceApplications': {
+          ListMobileDeviceApplicationsSchema.parse(args);
+          const applications = await jamfClient.listMobileDeviceApplications();
+
+          const content: TextContent = {
+            type: 'text',
+            text: JSON.stringify({
+              count: applications.length,
+              applications,
+            }, null, 2),
+          };
+
+          return { content: [content] };
+        }
+
+        case 'getMobileDeviceApplicationDetails': {
+          const { applicationId } = GetMobileDeviceApplicationDetailsSchema.parse(args);
+          const application = await jamfClient.getMobileDeviceApplicationDetails(applicationId);
+
+          const content: TextContent = {
+            type: 'text',
+            text: JSON.stringify(application, null, 2),
           };
 
           return { content: [content] };

--- a/src/types/jamf-client.ts
+++ b/src/types/jamf-client.ts
@@ -159,6 +159,10 @@ export interface IJamfApiClient {
   getMobileDeviceGroups(type?: GroupType): Promise<any[]>;
   getMobileDeviceGroupDetails(groupId: string): Promise<any>;
 
+  // Mobile Device Applications
+  listMobileDeviceApplications(): Promise<any[]>;
+  getMobileDeviceApplicationDetails(applicationId: string): Promise<any>;
+
   // Reports & Analytics
   getInventorySummary(): Promise<any>;
   getPolicyComplianceReport(policyId: string): Promise<any>;


### PR DESCRIPTION
## Summary
- Add Classic API methods and MCP tools for Jamf mobile device application delivery inventory.
- Expose the reads in Code Mode search and policy with dedicated `read:mobile_device_applications` capability gating.
- Add coverage and update README tool counts/docs.

## Validation
- `npm test`
- `git diff --check upstream/main...HEAD`
- `npm run lint` (fails on pre-existing `src/jamf-client-hybrid.ts:743` unused `limit` error outside this change).