### PR TITLE
fix: paginate computer inventory beyond API page cap

### DIFF
--- a/src/__tests__/jamf-client-hybrid.pagination.test.ts
+++ b/src/__tests__/jamf-client-hybrid.pagination.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { JamfApiClientHybrid } from '../jamf-client-hybrid.js';
+
+/**
+ * Regression test for the fleet-truncation bug: searchComputers used to fetch a
+ * single page (page-size=limit) and return only response.data.results, silently
+ * capping any fleet larger than the limit. It now walks pages up to totalCount.
+ */
+function makeClient(totalCount: number) {
+  const client = new JamfApiClientHybrid({
+    baseUrl: 'https://example.jamfcloud.com',
+    clientId: 'test',
+    clientSecret: 'test',
+    readOnlyMode: true,
+  } as any);
+
+  // Skip real auth. Serve sequential ids page by page, honouring page-size and
+  // stopping at totalCount — the same shape the Jamf Pro API returns.
+  (client as any).ensureAuthenticated = jest.fn(async () => {});
+  const calls: any[] = [];
+  let cursor = 0;
+  const get = jest.fn(async (_url: string, opts: any) => {
+    calls.push(opts.params);
+    const size = opts.params['page-size'] as number;
+    const results: any[] = [];
+    for (let i = 0; i < size && cursor < totalCount; i++) {
+      results.push({ id: String(cursor++), general: { name: `Mac-${cursor}` } });
+    }
+    return { data: { totalCount, results } };
+  });
+  (client as any).axiosInstance = { get };
+  return { client, calls };
+}
+
+describe('searchComputers pagination', () => {
+  it('walks every page and returns the whole fleet, not just the first page', async () => {
+    // 4,500 devices → 3 pages of 2000/2000/500 (mirrors the real 3,612 case)
+    const { client, calls } = makeClient(4500);
+
+    const all = await client.getAllComputers();
+
+    expect(all).toHaveLength(4500); // was capped at 1000 before the fix
+    expect(calls).toHaveLength(3);
+    expect(calls.map((c) => c.page)).toEqual([0, 1, 2]);
+    expect(calls[0].sort).toBe('id:asc'); // stable order across pages
+  });
+
+  it('stops at the caller limit without over-fetching', async () => {
+    const { client, calls } = makeClient(5000);
+
+    const some = await client.searchComputers('', 2);
+
+    expect(some).toHaveLength(2);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]['page-size']).toBe(2);
+  });
+});

--- a/src/code-mode/sandbox-runner.ts
+++ b/src/code-mode/sandbox-runner.ts
@@ -43,12 +43,14 @@ function getTimeout(): number {
 function createHelpers() {
   return {
     /**
-     * Auto-paginate a list call.
-     * Usage: await helpers.paginate(limit => jamf.getAllComputers(limit), 500)
+     * Fetch a full list. The Jamf list methods (getAllComputers, searchComputers,
+     * …) now paginate internally up to the limit you pass, so this forwards a high
+     * default to retrieve everything. Pass a smaller `limit` to cap the result.
+     * Usage: await helpers.paginate(limit => jamf.getAllComputers(limit))
      */
     paginate: async (
       fn: (limit: number) => Promise<unknown[]>,
-      limit = 500,
+      limit = 20000,
     ): Promise<unknown[]> => {
       return fn(limit);
     },

--- a/src/code-mode/search-index.ts
+++ b/src/code-mode/search-index.ts
@@ -175,7 +175,7 @@ const CATALOG: SearchIndexEntry[] = [
 // ── Helper entries ─────────────────────────────────────────────────
 
 const HELPER_ENTRIES: SearchIndexEntry[] = [
-  { name: 'helpers.paginate',  signature: '(fn: (limit: number) => Promise<any[]>, limit?: number) => Promise<any[]>', description: 'Auto-paginate a list call. Usage: await helpers.paginate(l => jamf.getAllComputers(l), 500)', category: 'helpers', capabilities: [], readOnly: true },
+  { name: 'helpers.paginate',  signature: '(fn: (limit: number) => Promise<any[]>, limit?: number) => Promise<any[]>', description: 'Fetch a full list (list methods paginate internally up to the limit). Usage: await helpers.paginate(l => jamf.getAllComputers(l))', category: 'helpers', capabilities: [], readOnly: true },
   { name: 'helpers.daysSince', signature: '(isoDate?: string | null) => number',                                       description: 'Calculate days since an ISO date string. Returns Infinity for null/undefined.',              category: 'helpers', capabilities: [], readOnly: true },
   { name: 'helpers.chunk',     signature: '<T>(arr: T[], size: number) => T[][]',                                       description: 'Split an array into chunks of the given size.',                                             category: 'helpers', capabilities: [], readOnly: true },
 ];

--- a/src/jamf-client-hybrid.ts
+++ b/src/jamf-client-hybrid.ts
@@ -461,37 +461,59 @@ export class JamfApiClientHybrid implements IJamfApiClient {
   private async _searchComputersImpl(query: string, limit: number): Promise<Computer[]> {
     await this.ensureAuthenticated();
 
-    // Try Jamf Pro API first
+    // Try Jamf Pro API first — paginate across pages up to `limit`.
+    // The /computers-inventory endpoint caps page-size (~2000), so a single
+    // request silently truncates larger fleets. Walk pages until we have
+    // `limit` records or have reached totalCount.
     try {
       logger.info('Searching computers using Jamf Pro API...');
-      const params: Record<string, string | number> = {
-        'page-size': limit,
-      };
-      
-      // Only add filter if there's a query
-      if (query && query.trim() !== '') {
-        // Try simpler filter syntax
-        params.filter = `general.name=="*${query}*"`;
+      const JAMF_MAX_PAGE_SIZE = 2000; // Jamf computers-inventory per-page hard cap
+      const filter =
+        query && query.trim() !== '' ? `general.name=="*${query}*"` : undefined;
+
+      const collected: Computer[] = [];
+      let page = 0;
+      let totalCount = Infinity;
+
+      while (collected.length < limit && collected.length < totalCount) {
+        const pageSize = Math.min(JAMF_MAX_PAGE_SIZE, limit - collected.length);
+        const params: Record<string, string | number> = {
+          'page-size': pageSize,
+          page,
+          sort: 'id:asc', // stable order so pages don't overlap or skip records
+        };
+        if (filter) params.filter = filter;
+
+        const response = await this.axiosInstance.get('/api/v1/computers-inventory', {
+          params,
+        });
+
+        if (typeof response.data.totalCount === 'number') {
+          totalCount = response.data.totalCount;
+        }
+
+        const results: any[] = response.data.results || [];
+        for (const computer of results) {
+          collected.push({
+            id: computer.id,
+            name: computer.general?.name || '',
+            udid: computer.general?.udid || '',
+            serialNumber: computer.general?.serialNumber || '',
+            lastContactTime: computer.general?.lastContactTime,
+            lastReportDate: computer.general?.lastReportDate,
+            osVersion: computer.operatingSystem?.version,
+            ipAddress: computer.general?.lastIpAddress,
+            macAddress: computer.general?.macAddress,
+            assetTag: computer.general?.assetTag,
+            modelIdentifier: computer.hardware?.modelIdentifier,
+          });
+        }
+
+        if (results.length < pageSize) break; // last page reached
+        page++;
       }
-      
-      const response = await this.axiosInstance.get('/api/v1/computers-inventory', {
-        params,
-      });
-      
-      // Transform modern response
-      return response.data.results.map((computer: any) => ({
-        id: computer.id,
-        name: computer.general?.name || '',
-        udid: computer.general?.udid || '',
-        serialNumber: computer.general?.serialNumber || '',
-        lastContactTime: computer.general?.lastContactTime,
-        lastReportDate: computer.general?.lastReportDate,
-        osVersion: computer.operatingSystem?.version,
-        ipAddress: computer.general?.lastIpAddress,
-        macAddress: computer.general?.macAddress,
-        assetTag: computer.general?.assetTag,
-        modelIdentifier: computer.hardware?.modelIdentifier,
-      }));
+
+      return collected.slice(0, limit);
     } catch (error) {
       const axiosError = error as AxiosError;
       if (axiosError.response?.status === 403) {
@@ -634,7 +656,9 @@ export class JamfApiClientHybrid implements IJamfApiClient {
   /**
    * Get all computers (for compatibility)
    */
-  async getAllComputers(limit: number = 1000): Promise<any[]> {
+  // ponytail: 20000 is a safety ceiling for "all"; searchComputers paginates up
+  // to it. Raise it if a fleet ever exceeds that many managed computers.
+  async getAllComputers(limit: number = 20000): Promise<any[]> {
     const computers = await this.searchComputers('', limit);
     return computers.map(c => ({
       id: c.id,


### PR DESCRIPTION
## Summary

Fixes computer inventory reads that could silently return only a single page when the fleet exceeded the Jamf Pro API page-size limit.

- Pages `/api/v1/computers-inventory` in stable `id:asc` order, with a maximum page size of 2,000.
- Continues until the API `totalCount` is reached, the final partial page is received, or the caller’s requested limit is met.
- Raises the default `getAllComputers()` and `helpers.paginate()` safety ceiling to 20,000 while retaining an explicit caller limit.
- Updates Code Mode search/help text to describe the internally paginated behaviour.
- Adds a regression test for a 4,500-device fleet, asserting three requests of 2,000 / 2,000 / 500 records.

## Why

Previously, a request for all computers could issue one inventory request and silently truncate results for fleets larger than the API page limit. This could make fleet reports and compliance calculations incomplete.

## Validation

- Added pagination regression coverage.
- TypeScript syntax and diff checks passed.
- Full test, lint, and build runs should be confirmed in CI.