### PR TITLE
feat: add read-only Mac App Store application support

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,10 @@ These combine multiple API calls into a single operation:
 - **createAdvancedComputerSearch**: Create a new advanced search (requires confirmation)
 - **deleteAdvancedComputerSearch**: Delete a saved search (requires confirmation)
 
+### Mac App Store Applications
+- **listMacApplications**: List Mac App Store (VPP) applications configured for delivery
+- **getMacApplicationDetails**: Get a Mac App Store application definition, catalog version, and scope details
+
 ### Mobile Device Management
 - **searchMobileDevices**: Search mobile devices by name, serial, or UDID
 - **getMobileDeviceDetails**: Detailed mobile device information

--- a/src/__tests__/code-mode/policy-engine.test.ts
+++ b/src/__tests__/code-mode/policy-engine.test.ts
@@ -24,6 +24,15 @@ describe('PolicyEngine', () => {
       expect(getMethodPolicy('getMobileDeviceApplicationDetails')).toEqual(policy);
     });
 
+    it('requires a dedicated capability for Mac App Store applications', () => {
+      const policy = getMethodPolicy('listMacApplications');
+      expect(policy).toEqual({
+        classification: 'read',
+        capability: 'read:mac_applications',
+      });
+      expect(getMethodPolicy('getMacApplicationDetails')).toEqual(policy);
+    });
+
     it('returns undefined for unknown methods', () => {
       expect(getMethodPolicy('nonExistentMethod')).toBeUndefined();
     });
@@ -39,6 +48,18 @@ describe('PolicyEngine', () => {
       const result = checkAccess('listMobileDeviceApplications', ['read:mobile_devices']);
       expect(result.allowed).toBe(false);
       expect(result.reason).toContain('read:mobile_device_applications');
+    });
+
+    it('grants Mac App Store application reads only with their dedicated capability', () => {
+      for (const method of ['listMacApplications', 'getMacApplicationDetails']) {
+        expect(checkAccess(method, ['read:mac_applications']).allowed).toBe(true);
+
+        for (const capability of ['read:app_installers', 'read:computers', 'read:mobile_device_applications']) {
+          const result = checkAccess(method, [capability]);
+          expect(result.allowed).toBe(false);
+          expect(result.reason).toContain('read:mac_applications');
+        }
+      }
     });
 
     it('denies access when capability is not granted', () => {
@@ -69,6 +90,8 @@ describe('PolicyEngine', () => {
       expect(getClassification('getAllComputers')).toBe('read');
       expect(getClassification('listPolicies')).toBe('read');
       expect(getClassification('searchScripts')).toBe('read');
+      expect(getClassification('listMacApplications')).toBe('read');
+      expect(getClassification('getMacApplicationDetails')).toBe('read');
     });
 
     it('classifies write methods', () => {

--- a/src/__tests__/code-mode/sandbox-runner.test.ts
+++ b/src/__tests__/code-mode/sandbox-runner.test.ts
@@ -57,6 +57,8 @@ function createMockClient(overrides: Partial<IJamfApiClient> = {}): IJamfApiClie
     sendMDMCommand: jest.fn().mockResolvedValue(undefined),
     getMobileDeviceGroups: jest.fn().mockResolvedValue([]),
     getMobileDeviceGroupDetails: jest.fn().mockResolvedValue({}),
+    listMacApplications: jest.fn().mockResolvedValue([{ id: '5', name: 'Example Mac App' }]),
+    getMacApplicationDetails: jest.fn().mockResolvedValue({ general: { id: '5', name: 'Example Mac App', version: '14.5' } }),
     listMobileDeviceApplications: jest.fn().mockResolvedValue([{ id: '123', name: 'Example Mobile App' }]),
     getMobileDeviceApplicationDetails: jest.fn().mockResolvedValue({ general: { id: '123', name: 'Example Mobile App' } }),
     getInventorySummary: jest.fn().mockResolvedValue({}),
@@ -183,6 +185,48 @@ describe('SandboxRunner', () => {
       expect(result.returnValue).toEqual({ general: { id: '123', name: 'Example Mobile App' } });
       expect(result.metrics.reads).toBe(1);
       expect(client.getMobileDeviceApplicationDetails).toHaveBeenCalledWith('123');
+    });
+
+    it('lists Mac App Store applications as a single read in plan mode', async () => {
+      const client = createMockClient();
+      const result = await execute(client, {
+        code: 'return await jamf.listMacApplications();',
+        mode: 'plan',
+        capabilities: ['read:mac_applications'],
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.returnValue).toEqual([{ id: '5', name: 'Example Mac App' }]);
+      expect(result.metrics).toMatchObject({ reads: 1, writes: 0, commands: 0 });
+      expect(client.listMacApplications).toHaveBeenCalledWith();
+    });
+
+    it('reads Mac App Store application catalog details as a single read in plan mode', async () => {
+      const client = createMockClient();
+      const result = await execute(client, {
+        code: 'return await jamf.getMacApplicationDetails("5");',
+        mode: 'plan',
+        capabilities: ['read:mac_applications'],
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.returnValue).toEqual({ general: { id: '5', name: 'Example Mac App', version: '14.5' } });
+      expect(result.metrics).toMatchObject({ reads: 1, writes: 0, commands: 0 });
+      expect(client.getMacApplicationDetails).toHaveBeenCalledWith('5');
+    });
+
+    it('rejects Mac App Store application reads without their dedicated capability', async () => {
+      for (const capability of ['read:app_installers', 'read:computers', 'read:mobile_device_applications']) {
+        const client = createMockClient();
+        const result = await execute(client, {
+          code: 'return await jamf.listMacApplications();',
+          mode: 'plan',
+          capabilities: [capability],
+        });
+
+        expect(result.success).toBe(false);
+        expect(client.listMacApplications).not.toHaveBeenCalled();
+      }
     });
   });
 

--- a/src/__tests__/code-mode/search-index.test.ts
+++ b/src/__tests__/code-mode/search-index.test.ts
@@ -26,6 +26,7 @@ describe('SearchIndex', () => {
       expect(cats).toContain('policies');
       expect(cats).toContain('scripts');
       expect(cats).toContain('reports');
+      expect(cats).toContain('mac_applications');
       expect(cats).toContain('helpers');
     });
   });
@@ -65,6 +66,24 @@ describe('SearchIndex', () => {
         capabilities: ['read:mobile_device_applications'],
         readOnly: true,
       });
+    });
+
+    it('finds read-only Mac App Store application inventory by name or VPP', () => {
+      for (const query of ['Mac App Store', 'VPP']) {
+        const results = search(query);
+        expect(results.map(result => result.name)).toContain('listMacApplications');
+        expect(results.map(result => result.name)).toContain('getMacApplicationDetails');
+
+        for (const method of ['listMacApplications', 'getMacApplicationDetails']) {
+          expect(results.find(result => result.name === method)).toMatchObject({
+            category: 'mac_applications',
+            capabilities: ['read:mac_applications'],
+            readOnly: true,
+          });
+        }
+      }
+
+      expect(search('getMacApplicationDetails')[0].name).toBe('getMacApplicationDetails');
     });
 
     it('ranks exact name matches highest', () => {

--- a/src/__tests__/mac-applications.test.ts
+++ b/src/__tests__/mac-applications.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { JamfApiClientHybrid } from '../jamf-client-hybrid.js';
+import { registerTools } from '../tools/index.js';
+import { IJamfApiClient } from '../types/jamf-client.js';
+
+type RegisteredHandler = (...args: unknown[]) => Promise<unknown>;
+
+function registerMacApplicationTools(client: IJamfApiClient): RegisteredHandler[] {
+  const handlers: RegisteredHandler[] = [];
+  const server = {
+    setRequestHandler: (_schema: unknown, handler: RegisteredHandler) => {
+      handlers.push(handler);
+    },
+  } as unknown as Server;
+
+  registerTools(server, client);
+  return handlers;
+}
+
+describe('Mac App Store applications', () => {
+  describe('Classic API client', () => {
+    it('reads Mac App Store list and detail response envelopes', async () => {
+      const application = { general: { id: '5', name: 'Example Mac App', version: '14.5' } };
+      const get = jest.fn()
+        .mockResolvedValueOnce({ data: { mac_applications: [{ id: '5', name: 'Example Mac App' }] } })
+        .mockResolvedValueOnce({ data: { mac_application: application } });
+      const client = Object.create(JamfApiClientHybrid.prototype) as JamfApiClientHybrid;
+
+      Object.defineProperties(client, {
+        ensureAuthenticated: { value: jest.fn().mockResolvedValue(undefined) },
+        axiosInstance: { value: { get } },
+      });
+
+      await expect(client.listMacApplications()).resolves.toEqual([{ id: '5', name: 'Example Mac App' }]);
+      await expect(client.getMacApplicationDetails('5')).resolves.toEqual(application);
+      expect(get).toHaveBeenNthCalledWith(1, '/JSSResource/macapplications');
+      expect(get).toHaveBeenNthCalledWith(2, '/JSSResource/macapplications/id/5');
+    });
+
+    it.each(['../policies/id/1', '1/../../policies', '1?subset=General', '0', '-1', '1.0', ''])
+      ('rejects invalid Mac application IDs before authentication or network access: %s', async (applicationId) => {
+        const ensureAuthenticated = jest.fn();
+        const get = jest.fn();
+        const client = Object.create(JamfApiClientHybrid.prototype) as JamfApiClientHybrid;
+
+        Object.defineProperties(client, {
+          ensureAuthenticated: { value: ensureAuthenticated },
+          axiosInstance: { value: { get } },
+        });
+
+        await expect(client.getMacApplicationDetails(applicationId))
+          .rejects.toThrow('Mac application ID must be a positive integer');
+        expect(ensureAuthenticated).not.toHaveBeenCalled();
+        expect(get).not.toHaveBeenCalled();
+      });
+  });
+
+  describe('Classic MCP tools', () => {
+    it('marks both Mac App Store application tools read-only and non-destructive', async () => {
+      const handlers = registerMacApplicationTools({} as IJamfApiClient);
+      const response = await handlers[0]() as {
+        tools: Array<{ name: string; annotations?: { readOnlyHint: boolean; destructiveHint: boolean } }>;
+      };
+
+      for (const name of ['listMacApplications', 'getMacApplicationDetails']) {
+        expect(response.tools.find(tool => tool.name === name)?.annotations).toEqual({
+          readOnlyHint: true,
+          destructiveHint: false,
+        });
+      }
+    });
+
+    it('dispatches list and detail reads through the Classic MCP handlers', async () => {
+      const listMacApplications = jest.fn().mockResolvedValue([{ id: '5', name: 'Example Mac App' }]);
+      const getMacApplicationDetails = jest.fn()
+        .mockResolvedValue({ general: { id: '5', name: 'Example Mac App', version: '14.5' } });
+      const handlers = registerMacApplicationTools({
+        listMacApplications,
+        getMacApplicationDetails,
+      } as unknown as IJamfApiClient);
+
+      const listResponse = await handlers[1]({ params: { name: 'listMacApplications', arguments: {} } }) as {
+        content: Array<{ text: string }>;
+      };
+      expect(JSON.parse(listResponse.content[0].text)).toEqual({
+        count: 1,
+        applications: [{ id: '5', name: 'Example Mac App' }],
+      });
+
+      const detailResponse = await handlers[1]({
+        params: { name: 'getMacApplicationDetails', arguments: { applicationId: '5' } },
+      }) as { content: Array<{ text: string }> };
+      expect(JSON.parse(detailResponse.content[0].text)).toEqual({
+        general: { id: '5', name: 'Example Mac App', version: '14.5' },
+      });
+      expect(getMacApplicationDetails).toHaveBeenCalledWith('5');
+    });
+
+    it('rejects non-numeric Mac application IDs before invoking the Classic handler client', async () => {
+      const getMacApplicationDetails = jest.fn();
+      const handlers = registerMacApplicationTools({ getMacApplicationDetails } as unknown as IJamfApiClient);
+      const response = await handlers[1]({
+        params: {
+          name: 'getMacApplicationDetails',
+          arguments: { applicationId: '../policies/id/1' },
+        },
+      }) as { isError?: boolean; content: Array<{ text: string }> };
+
+      expect(response.isError).toBe(true);
+      expect(response.content[0].text).toContain('Mac application ID must be a positive integer');
+      expect(getMacApplicationDetails).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/code-mode/policy-engine.ts
+++ b/src/code-mode/policy-engine.ts
@@ -83,6 +83,10 @@ const METHOD_POLICIES: Record<string, MethodPolicy> = {
   getMobileDeviceGroups:        { classification: 'read', capability: 'read:mobile_devices' },
   getMobileDeviceGroupDetails:  { classification: 'read', capability: 'read:mobile_devices' },
 
+  // Mac App Store Applications
+  listMacApplications:          { classification: 'read', capability: 'read:mac_applications' },
+  getMacApplicationDetails:     { classification: 'read', capability: 'read:mac_applications' },
+
   // Mobile Device Applications
   listMobileDeviceApplications: { classification: 'read', capability: 'read:mobile_device_applications' },
   getMobileDeviceApplicationDetails: { classification: 'read', capability: 'read:mobile_device_applications' },

--- a/src/code-mode/search-index.ts
+++ b/src/code-mode/search-index.ts
@@ -76,6 +76,10 @@ const CATALOG: SearchIndexEntry[] = [
   { name: 'getMobileDeviceGroups',       signature: '(type?: GroupType) => Promise<any[]>',     description: 'List mobile device groups',               category: 'mobile_devices', capabilities: ['read:mobile_devices'], readOnly: true },
   { name: 'getMobileDeviceGroupDetails', signature: '(groupId: string) => Promise<any>',        description: 'Get details for a mobile device group',   category: 'mobile_devices', capabilities: ['read:mobile_devices'], readOnly: true },
 
+  // ── Mac App Store Applications ──────────────────────────────────
+  { name: 'listMacApplications', signature: '() => Promise<any[]>', description: 'List Mac App Store (VPP) applications configured for delivery', category: 'mac_applications', capabilities: ['read:mac_applications'], readOnly: true },
+  { name: 'getMacApplicationDetails', signature: '(applicationId: string) => Promise<any>', description: 'Get Mac App Store (VPP) application details, catalog version, and scope', category: 'mac_applications', capabilities: ['read:mac_applications'], readOnly: true },
+
   // ── Mobile Device Applications ───────────────────────────────────
   { name: 'listMobileDeviceApplications', signature: '() => Promise<any[]>', description: 'List all mobile device applications configured for delivery', category: 'mobile_device_applications', capabilities: ['read:mobile_device_applications'], readOnly: true },
   { name: 'getMobileDeviceApplicationDetails', signature: '(applicationId: string) => Promise<any>', description: 'Get details for a mobile device application configured for delivery', category: 'mobile_device_applications', capabilities: ['read:mobile_device_applications'], readOnly: true },

--- a/src/jamf-client-hybrid.ts
+++ b/src/jamf-client-hybrid.ts
@@ -2000,6 +2000,48 @@ export class JamfApiClientHybrid implements IJamfApiClient {
   }
 
   /**
+   * List all Mac App Store applications configured for delivery
+   */
+  async listMacApplications(): Promise<any[]> {
+    await this.ensureAuthenticated();
+
+    try {
+      logger.info('Listing Mac App Store applications using Classic API...');
+      const response = await this.axiosInstance.get('/JSSResource/macapplications');
+      return response.data.mac_applications || [];
+    } catch (error) {
+      if (isAxiosError(error)) {
+        throw JamfAPIError.fromAxiosError(error, { operation: 'listMacApplications' });
+      }
+      logger.error('Failed to list Mac App Store applications:', { error: getErrorMessage(error) });
+      throw error;
+    }
+  }
+
+  /**
+   * Get details for a Mac App Store application configured for delivery
+   */
+  async getMacApplicationDetails(applicationId: string): Promise<any> {
+    if (typeof applicationId !== 'string' || !/^[1-9]\d*$/.test(applicationId)) {
+      throw new Error('Mac application ID must be a positive integer');
+    }
+
+    await this.ensureAuthenticated();
+
+    try {
+      logger.info(`Getting Mac App Store application details for ${applicationId} using Classic API...`);
+      const response = await this.axiosInstance.get(`/JSSResource/macapplications/id/${applicationId}`);
+      return response.data.mac_application;
+    } catch (error) {
+      if (isAxiosError(error)) {
+        throw JamfAPIError.fromAxiosError(error, { operation: 'getMacApplicationDetails', applicationId });
+      }
+      logger.error('Failed to get Mac App Store application details:', { error: getErrorMessage(error) });
+      throw error;
+    }
+  }
+
+  /**
    * List all mobile device applications configured for delivery
    */
   async listMobileDeviceApplications(): Promise<any[]> {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -186,6 +186,14 @@ const ListMobileDevicesSchema = z.object({
   limit: z.number().optional().default(50).describe('Maximum number of mobile devices to return'),
 });
 
+const ListMacApplicationsSchema = z.object({});
+
+const GetMacApplicationDetailsSchema = z.object({
+  applicationId: z.string()
+    .regex(/^[1-9]\d*$/, 'Mac application ID must be a positive integer')
+    .describe('The Mac App Store application ID'),
+});
+
 const ListMobileDeviceApplicationsSchema = z.object({});
 
 const GetMobileDeviceApplicationDetailsSchema = z.object({
@@ -1410,6 +1418,30 @@ export function registerTools(server: Server, jamfClient: IJamfApiClient): void 
               default: 50,
             },
           },
+        },
+        annotations: { readOnlyHint: true, destructiveHint: false },
+      },
+      {
+        name: 'listMacApplications',
+        description: 'List all Mac App Store (VPP) applications configured for delivery in Jamf Pro',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+        },
+        annotations: { readOnlyHint: true, destructiveHint: false },
+      },
+      {
+        name: 'getMacApplicationDetails',
+        description: 'Get Mac App Store (VPP) application details, including the catalog version and delivery scope',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            applicationId: {
+              type: 'string',
+              description: 'The Mac App Store application ID',
+            },
+          },
+          required: ['applicationId'],
         },
         annotations: { readOnlyHint: true, destructiveHint: false },
       },
@@ -4018,6 +4050,33 @@ export function registerTools(server: Server, jamfClient: IJamfApiClient): void 
                 supervised: d.supervised,
               })),
             }, null, 2),
+          };
+
+          return { content: [content] };
+        }
+
+        case 'listMacApplications': {
+          ListMacApplicationsSchema.parse(args);
+          const applications = await jamfClient.listMacApplications();
+
+          const content: TextContent = {
+            type: 'text',
+            text: JSON.stringify({
+              count: applications.length,
+              applications,
+            }, null, 2),
+          };
+
+          return { content: [content] };
+        }
+
+        case 'getMacApplicationDetails': {
+          const { applicationId } = GetMacApplicationDetailsSchema.parse(args);
+          const application = await jamfClient.getMacApplicationDetails(applicationId);
+
+          const content: TextContent = {
+            type: 'text',
+            text: JSON.stringify(application, null, 2),
           };
 
           return { content: [content] };

--- a/src/types/jamf-client.ts
+++ b/src/types/jamf-client.ts
@@ -159,6 +159,10 @@ export interface IJamfApiClient {
   getMobileDeviceGroups(type?: GroupType): Promise<any[]>;
   getMobileDeviceGroupDetails(groupId: string): Promise<any>;
 
+  // Mac App Store Applications
+  listMacApplications(): Promise<any[]>;
+  getMacApplicationDetails(applicationId: string): Promise<any>;
+
   // Mobile Device Applications
   listMobileDeviceApplications(): Promise<any[]>;
   getMobileDeviceApplicationDetails(applicationId: string): Promise<any>;


### PR DESCRIPTION
## Summary

- Add read-only Classic API methods `listMacApplications()` and `getMacApplicationDetails(applicationId)` for Mac App Store / VPP application definitions.
- Expose both methods as annotated read-only Classic MCP tools and searchable Code Mode SDK methods.
- Require the dedicated `read:mac_applications` capability; adjacent computer, App Installer, and mobile-application capabilities cannot access these methods.
- Validate positive numeric application identifiers before authentication or network access and again at the Classic tool boundary.
- Return standard Jamf Classic list/detail response envelopes, including application catalog-version and delivery-scope metadata.
- Document the new tools in the README.

## Validation

- `npm test`: 13 Jest suites / 230 tests and 8 mocked skill checks passed.
- `npm run build`, `npm run typecheck`, and `npm run lint` passed.
- Focused tests cover list/detail response envelopes, invalid identifiers, read-only tool annotations, Classic tool dispatch, Code Mode search, capability isolation, and zero-write plan-mode execution.
- An authenticated end-to-end MCP smoke test discovered both methods and successfully retrieved application details using two read operations, zero writes, and zero device commands.